### PR TITLE
User can confirm order

### DIFF
--- a/cypress/integration/userCanAddProductsToOrder.feature.js
+++ b/cypress/integration/userCanAddProductsToOrder.feature.js
@@ -85,16 +85,20 @@ describe("User can add a product to his/her order", () => {
       .click();
 
     cy.get("#order-details").should("not.exist");
-  });
 
-  it('user can confirm order', () => {
     cy.get("button")
       .contains("View order")
       .click();
+    cy.route({
+      method: 'PUT',
+      url: "http://localhost:3000/api/orders/1",
+      response: { message: 'Your order is ready to be picked up in 30 minutes' }
+    })
 
     cy.get('#confirm').click()
-    cy.get('')
-  })
+    cy.get('.message').should('contain', 'Your order is ready to be picked up in 30 minutes')
+
+  });
 });
 
 

--- a/cypress/integration/userCanAddProductsToOrder.feature.js
+++ b/cypress/integration/userCanAddProductsToOrder.feature.js
@@ -86,4 +86,15 @@ describe("User can add a product to his/her order", () => {
 
     cy.get("#order-details").should("not.exist");
   });
+
+  it('user can confirm order', () => {
+    cy.get("button")
+      .contains("View order")
+      .click();
+
+    cy.get('#confirm').click()
+    cy.get('')
+  })
 });
+
+

--- a/src/components/DisplayMenuAndOrder.jsx
+++ b/src/components/DisplayMenuAndOrder.jsx
@@ -39,9 +39,9 @@ class DisplayMenuAndOrder extends Component {
     });
   }
 
-  finalizeOrder() {
-    this.setState({
-      message: { id: 0, message: "Your order will be ready in 30 minutes!" }
+  async confirmOrder() {
+      let result = await axios.put(`/orders/${this.state.orderDetails.id}`, { activity: 'confirm' })
+      this.setState({ message: { id: 0, message: result.data.message }, orderDetails: {}
     });
   }
 
@@ -150,7 +150,7 @@ class DisplayMenuAndOrder extends Component {
           <>
             <ul id="order-details">{orderDetailsDisplay}</ul>
             <p>Total: {this.state.orderDetails.order_total} kr</p>
-            <button onClick={this.finalizeOrder.bind(this)}>Confirm!</button>
+            <button id='confirm' onClick={this.confirmOrder.bind(this)}>Confirm Order</button>
           </>
         )}
         <h2>Starters</h2>


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171460089)
```
As a user,
In order to get the food in my order
I need to be able to confirm the order
```
## Changes proposed in this pull request:
* Adds acceptance test for user to confirm order
* Adds functionality to send a PUT request to the API so confirm order
* Adds functionality that the user can not add more products to order after confirming it
## What I have learned working on this feature:
* How a PUT request can be used in different ways depending on params to get another output from the API
* Better understanding on how to connect the dots between API and client on different features
## Screenshots (Only if client side story)
<img width="453" alt="Screenshot 2020-03-09 at 20 36 48" src="https://user-images.githubusercontent.com/59577366/76250461-b5c3e080-6245-11ea-927a-5d391877d7ca.png">
<img width="615" alt="Screenshot 2020-03-09 at 20 37 06" src="https://user-images.githubusercontent.com/59577366/76250498-c2e0cf80-6245-11ea-8a04-62f7ed85c0e5.png">
